### PR TITLE
Fixed memory leak

### DIFF
--- a/regex.mod/regex.bmx
+++ b/regex.mod/regex.bmx
@@ -732,14 +732,14 @@ Type TRegExMatch
 	Rem
 	bbdoc: Returns the end position of the subexpression for the given @name.
 	End Rem
-	Method SubEnd:Size_T(name:String)
+	Method SubEnd:Int(name:String)
 		Return SubEndByName(name)
 	End Method
 
 	Rem
 	bbdoc: Returns the end position of the subexpression for the given @name.
 	End Rem
-	Method SubEndByName:Size_T(name:String)
+	Method SubEndByName:Int(name:String)
 		If name Then
 			Local n:Short Ptr = name.ToWString()
 			Local index:Int = pcre2_substring_number_from_name_16(pcre, n)

--- a/regex.mod/regex.bmx
+++ b/regex.mod/regex.bmx
@@ -132,6 +132,10 @@ Type TRegEx
 			pcre2_match_data_free_16(matchPtr)
 		End If
 		
+		If pcre
+			MemFree(pcre)
+		EndIf
+		
 	End Method
 
 	Rem
@@ -414,6 +418,10 @@ Type TRegEx
 		MemFree(pat)
 		
 		If bptr Then
+			If pcre
+				MemFree(pcre)
+			EndIf
+			
 			pcre = bptr
 		Else
 			Local buffer:Short[256]

--- a/regex.mod/regex.bmx
+++ b/regex.mod/regex.bmx
@@ -243,7 +243,7 @@ Type TRegEx
 			offsets = pcre2_get_ovector_pointer_16(matchPtr)
 
 			Local replaceStr:String = replaceWith 
-			Local ofs:Int Ptr = offsets
+			Local ofs:Long Ptr = offsets
 			For Local i:Int = 0 Until result
 				Local idx:Int = i * 2
 				replaceStr = replaceStr.Replace( "\" + i, lastTarget[ofs[idx]..ofs[idx+1]])

--- a/regex.mod/regex.bmx
+++ b/regex.mod/regex.bmx
@@ -622,7 +622,7 @@ Type TRegExMatch
 	about: For expressions with no subpattern groups, this method can be used without a parameter
 	to return the start position of the matched string.
 	End Rem
-	Method SubStart:Size_T(matchNumber:Int = 0)
+	Method SubStart:Int(matchNumber:Int = 0)
 		If matchNumber >= 0 And matchNumber <  count Then
 
 			Local offsets:Size_T Ptr = pcre2_get_ovector_pointer_16(matchPtr)
@@ -638,7 +638,7 @@ Type TRegExMatch
 	about: For expressions with no subpattern groups, this method can be used without a parameter
 	to return the end position of the matched string.
 	End Rem
-	Method SubEnd:Size_T(matchNumber:Int = 0)
+	Method SubEnd:Int(matchNumber:Int = 0)
 		If matchNumber >= 0 And matchNumber <  count Then
 
 			Local offsets:Size_T Ptr = pcre2_get_ovector_pointer_16(matchPtr)
@@ -708,14 +708,14 @@ Type TRegExMatch
 	Rem
 	bbdoc: Returns the start position of the subexpression for the given @name.
 	End Rem
-	Method SubStart:Size_T(name:String)
+	Method SubStart:Int(name:String)
 		Return SubStartByName(name)
 	End Method
 
 	Rem
 	bbdoc: Returns the start position of the subexpression for the given @name.
 	End Rem
-	Method SubStartByName:Size_T(name:String)
+	Method SubStartByName:Int(name:String)
 		If name Then
 			Local n:Short Ptr = name.ToWString()
 			Local index:Int = pcre2_substring_number_from_name_16(pcre, n)

--- a/regex.mod/regex.bmx
+++ b/regex.mod/regex.bmx
@@ -107,7 +107,7 @@ Type TRegEx
 	' the length of the target string
 	Field targLength:Size_T
 	
-	Field lastEndPos:Int
+	Field lastEndPos:Size_T
 	
 	' pointer to the compiled expression
 	Field pcre:Byte Ptr
@@ -242,7 +242,7 @@ Type TRegEx
 			sizeOffsets = pcre2_get_ovector_count_16(matchPtr)
 			offsets = pcre2_get_ovector_pointer_16(matchPtr)
 
-			Local replaceStr:String = replaceWith 
+			Local replaceStr:String = replaceWith
 			Local ofs:Size_T Ptr = offsets
 			For Local i:Int = 0 Until result
 				Local idx:Int = i * 2
@@ -622,7 +622,7 @@ Type TRegExMatch
 	about: For expressions with no subpattern groups, this method can be used without a parameter
 	to return the start position of the matched string.
 	End Rem
-	Method SubStart:Int(matchNumber:Int = 0)
+	Method SubStart:Size_T(matchNumber:Int = 0)
 		If matchNumber >= 0 And matchNumber <  count Then
 
 			Local offsets:Size_T Ptr = pcre2_get_ovector_pointer_16(matchPtr)
@@ -638,7 +638,7 @@ Type TRegExMatch
 	about: For expressions with no subpattern groups, this method can be used without a parameter
 	to return the end position of the matched string.
 	End Rem
-	Method SubEnd:Int(matchNumber:Int = 0)
+	Method SubEnd:Size_T(matchNumber:Int = 0)
 		If matchNumber >= 0 And matchNumber <  count Then
 
 			Local offsets:Size_T Ptr = pcre2_get_ovector_pointer_16(matchPtr)
@@ -708,21 +708,21 @@ Type TRegExMatch
 	Rem
 	bbdoc: Returns the start position of the subexpression for the given @name.
 	End Rem
-	Method SubStart:Int(name:String)
+	Method SubStart:Size_T(name:String)
 		Return SubStartByName(name)
 	End Method
 
 	Rem
 	bbdoc: Returns the start position of the subexpression for the given @name.
 	End Rem
-	Method SubStartByName:Int(name:String)
+	Method SubStartByName:Size_T(name:String)
 		If name Then
 			Local n:Short Ptr = name.ToWString()
 			Local index:Int = pcre2_substring_number_from_name_16(pcre, n)
 			MemFree(n)
 			
 			If index >= 0 Then
-				Local offsets:Int Ptr = pcre2_get_ovector_pointer_16(matchPtr)
+				Local offsets:Size_T Ptr = pcre2_get_ovector_pointer_16(matchPtr)
 				Return offsets[index]
 			End If
 		End If
@@ -732,21 +732,21 @@ Type TRegExMatch
 	Rem
 	bbdoc: Returns the end position of the subexpression for the given @name.
 	End Rem
-	Method SubEnd:Int(name:String)
+	Method SubEnd:Size_T(name:String)
 		Return SubEndByName(name)
 	End Method
 
 	Rem
 	bbdoc: Returns the end position of the subexpression for the given @name.
 	End Rem
-	Method SubEndByName:Int(name:String)
+	Method SubEndByName:Size_T(name:String)
 		If name Then
 			Local n:Short Ptr = name.ToWString()
 			Local index:Int = pcre2_substring_number_from_name_16(pcre, n)
 			MemFree(n)
 			
 			If index >= 0 Then
-				Local offsets:Int Ptr = pcre2_get_ovector_pointer_16(matchPtr)
+				Local offsets:Size_T Ptr = pcre2_get_ovector_pointer_16(matchPtr)
 				Return offsets[index + 1] - 1
 			End If
 		End If

--- a/regex.mod/regex.bmx
+++ b/regex.mod/regex.bmx
@@ -243,7 +243,7 @@ Type TRegEx
 			offsets = pcre2_get_ovector_pointer_16(matchPtr)
 
 			Local replaceStr:String = replaceWith 
-			Local ofs:Long Ptr = offsets
+			Local ofs:Size_T Ptr = offsets
 			For Local i:Int = 0 Until result
 				Local idx:Int = i * 2
 				replaceStr = replaceStr.Replace( "\" + i, lastTarget[ofs[idx]..ofs[idx+1]])


### PR DESCRIPTION
Example:
```
Framework BRL.Blitz
Import BRL.StandardIO
Import Text.RegEx

Local html:String = "<div><div><div><div>Testing1</div></div></div><span>Hello</span><script>Testing2</script></div>"

Repeat
	Local regex:TRegEx = TRegEx.Create("<script(.*?)>(.*?)</script>")
	regex.ReplaceAll(html, "")

	GCCollect()
Forever
```